### PR TITLE
feat: implement Post entity, repository, and use case; add routes for…

### DIFF
--- a/internal/app/dependencies/clients.go
+++ b/internal/app/dependencies/clients.go
@@ -142,6 +142,16 @@ func ensureSchema(db *sql.DB) error {
             updated_by INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
             updated_at TIMESTAMP NOT NULL DEFAULT now()
         )`,
+		`CREATE TABLE IF NOT EXISTS posts (
+            id SERIAL PRIMARY KEY,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_by INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at TIMESTAMP NOT NULL DEFAULT now(),
+            updated_by INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            updated_at TIMESTAMP NOT NULL DEFAULT now(),
+            space_id INT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE
+        )`,
 	}
 
 	for _, stmt := range stmts {

--- a/internal/app/dependencies/dependencies.go
+++ b/internal/app/dependencies/dependencies.go
@@ -1,11 +1,14 @@
 package dependencies
 
 import (
+	postUsecase "cpi-hub-api/internal/core/usecase/post"
 	spaceUsecase "cpi-hub-api/internal/core/usecase/space"
 	userUsecase "cpi-hub-api/internal/core/usecase/user"
+	postRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/post"
 	spaceRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/space"
 	userRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/user"
 	userSpaceRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/user_space"
+	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/post"
 	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/space"
 	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/user"
 	"log"
@@ -14,6 +17,7 @@ import (
 type Handlers struct {
 	UserHandler  *user.Handler
 	SpaceHandler *space.SpaceHandler
+	PostHandler  *post.PostHandler
 }
 
 func Build() *Handlers {
@@ -26,9 +30,11 @@ func Build() *Handlers {
 	userRepository := userRepository.NewUserRepository(sqldb)
 	spaceRepository := spaceRepository.NewSpaceRepository(sqldb)
 	userSpaceRepository := userSpaceRepository.NewUserSpaceRepository(sqldb)
+	postRepository := postRepository.NewPostRepository(sqldb)
 
 	userUsecase := userUsecase.NewUserUsecase(userRepository, spaceRepository, userSpaceRepository)
 	spaceUsecase := spaceUsecase.NewSpaceUsecase(spaceRepository, userRepository, userSpaceRepository)
+	postUsecase := postUsecase.NewPostUsecase(postRepository, spaceRepository, userRepository)
 
 	return &Handlers{
 		UserHandler: &user.Handler{
@@ -36,6 +42,9 @@ func Build() *Handlers {
 		},
 		SpaceHandler: &space.SpaceHandler{
 			SpaceUseCase: spaceUsecase,
+		},
+		PostHandler: &post.PostHandler{
+			PostUseCase: postUsecase,
 		},
 	}
 }

--- a/internal/core/domain/post.go
+++ b/internal/core/domain/post.go
@@ -3,7 +3,7 @@ package domain
 import "time"
 
 type Post struct {
-	ID        string
+	ID        int
 	Title     string
 	Content   string
 	CreatedAt time.Time
@@ -14,8 +14,14 @@ type Post struct {
 	Comments  []Comment
 }
 
+type PostWithUserSpace struct {
+	Post  *Post
+	Space *Space
+	User  *User
+}
+
 type Comment struct {
-	ID        string
+	ID        int
 	Content   string
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/internal/core/domain/repositories.go
+++ b/internal/core/domain/repositories.go
@@ -21,3 +21,8 @@ type UserSpaceRepository interface {
 	FindSpaceIDsByUser(ctx context.Context, userID int) ([]int, error)
 	Exists(ctx context.Context, userId int, spaceId int) (bool, error)
 }
+
+type PostRepository interface {
+	Create(ctx context.Context, post *Post) error
+	Find(ctx context.Context, criteria *criteria.Criteria) (*Post, error)
+}

--- a/internal/core/dto/post.go
+++ b/internal/core/dto/post.go
@@ -1,0 +1,73 @@
+package dto
+
+import (
+	"cpi-hub-api/internal/core/domain"
+	"time"
+)
+
+type CreatePost struct {
+	Title     string `json:"title" binding:"required"`
+	Content   string `json:"content" binding:"required"`
+	CreatedBy int    `json:"created_by" binding:"required"`
+	SpaceID   int    `json:"space_id" binding:"required"`
+}
+
+type PostDTO struct {
+	ID        int       `json:"id"`
+	Title     string    `json:"title"`
+	Content   string    `json:"content"`
+	CreatedBy int       `json:"created_by"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedBy int       `json:"updated_by"`
+	SpaceID   int       `json:"space_id"`
+}
+
+type PostWithUserSpaceDTO struct {
+	ID        int            `json:"id"`
+	Title     string         `json:"title"`
+	Content   string         `json:"content"`
+	CreatedBy UserDTO        `json:"created_by"`
+	Space     SimpleSpaceDto `json:"space"`
+}
+
+func (c *CreatePost) ToDomain() *domain.Post {
+	return &domain.Post{
+		Title:     c.Title,
+		Content:   c.Content,
+		CreatedBy: c.CreatedBy,
+		SpaceID:   c.SpaceID,
+	}
+}
+
+func ToPostDTO(post *domain.Post) PostDTO {
+	return PostDTO{
+		ID:        post.ID,
+		Title:     post.Title,
+		Content:   post.Content,
+		CreatedBy: post.CreatedBy,
+		CreatedAt: post.CreatedAt,
+		UpdatedAt: post.UpdatedAt,
+		UpdatedBy: post.UpdatedBy,
+		SpaceID:   post.SpaceID,
+	}
+}
+
+func ToPostWithUserSpaceDTO(post *domain.PostWithUserSpace) PostWithUserSpaceDTO {
+	return PostWithUserSpaceDTO{
+		ID:      post.Post.ID,
+		Title:   post.Post.Title,
+		Content: post.Post.Content,
+		CreatedBy: UserDTO{
+			ID:       post.User.ID,
+			Name:     post.User.Name,
+			LastName: post.User.LastName,
+			Image:    post.User.Image,
+			Email:    post.User.Email,
+		},
+		Space: SimpleSpaceDto{
+			ID:   post.Space.ID,
+			Name: post.Space.Name,
+		},
+	}
+}

--- a/internal/core/dto/space.go
+++ b/internal/core/dto/space.go
@@ -21,6 +21,11 @@ type SpaceDTO struct {
 	UpdatedBy   int    `json:"updated_by"`
 }
 
+type SimpleSpaceDto struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
 type SpaceWithUserDTO struct {
 	ID          int     `json:"id"`
 	Name        string  `json:"name"`

--- a/internal/core/usecase/post/post_usecase.go
+++ b/internal/core/usecase/post/post_usecase.go
@@ -1,0 +1,142 @@
+package post
+
+import (
+	"context"
+	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/core/domain/criteria"
+	"cpi-hub-api/pkg/apperror"
+	"time"
+)
+
+type PostUseCase interface {
+	Create(ctx context.Context, post *domain.Post) (*domain.PostWithUserSpace, error)
+	Get(ctx context.Context, id string) (*domain.PostWithUserSpace, error)
+}
+
+type postUseCase struct {
+	postRepository  domain.PostRepository
+	spaceRepository domain.SpaceRepository
+	userRepository  domain.UserRepository
+}
+
+func NewPostUsecase(postRepo domain.PostRepository, spaceRepo domain.SpaceRepository, userRepo domain.UserRepository) PostUseCase {
+	return &postUseCase{
+		postRepository:  postRepo,
+		spaceRepository: spaceRepo,
+		userRepository:  userRepo,
+	}
+}
+
+func (p *postUseCase) Create(ctx context.Context, post *domain.Post) (*domain.PostWithUserSpace, error) {
+	existingUser, err := p.userRepository.Find(ctx, &criteria.Criteria{
+		Filters: []criteria.Filter{
+			{
+				Field:    "id",
+				Value:    post.CreatedBy,
+				Operator: criteria.OperatorEqual,
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if existingUser == nil {
+		return nil, apperror.NewNotFound("User not found", nil, "post_usecase.go:Create")
+	}
+
+	existingSpace, err := p.spaceRepository.Find(ctx, &criteria.Criteria{
+		Filters: []criteria.Filter{
+			{
+				Field:    "id",
+				Value:    post.SpaceID,
+				Operator: criteria.OperatorEqual,
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if existingSpace == nil {
+		return nil, apperror.NewNotFound("Space not found", nil, "post_usecase.go:Create")
+	}
+
+	post.CreatedAt, post.UpdatedAt = time.Now(), time.Now()
+	post.CreatedBy, post.UpdatedBy = existingUser.ID, existingUser.ID
+
+	err = p.postRepository.Create(ctx, post)
+	if err != nil {
+		return nil, err
+	}
+
+	return &domain.PostWithUserSpace{
+		Post:  post,
+		Space: existingSpace,
+		User:  existingUser,
+	}, nil
+}
+
+func (p *postUseCase) Get(ctx context.Context, id string) (*domain.PostWithUserSpace, error) {
+	post, err := p.postRepository.Find(ctx, &criteria.Criteria{
+		Filters: []criteria.Filter{
+			{
+				Field:    "id",
+				Value:    id,
+				Operator: criteria.OperatorEqual,
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if post == nil {
+		return nil, apperror.NewNotFound("Post not found", nil, "post_usecase.go:Get")
+	}
+
+	space, err := p.spaceRepository.Find(ctx, &criteria.Criteria{
+		Filters: []criteria.Filter{
+			{
+				Field:    "id",
+				Value:    post.SpaceID,
+				Operator: criteria.OperatorEqual,
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if space == nil {
+		return nil, apperror.NewNotFound("Space not found", nil, "post_usecase.go:Get")
+	}
+
+	user, err := p.userRepository.Find(ctx, &criteria.Criteria{
+		Filters: []criteria.Filter{
+			{
+				Field:    "id",
+				Value:    post.CreatedBy,
+				Operator: criteria.OperatorEqual,
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if user == nil {
+		return nil, apperror.NewNotFound("User not found", nil, "post_usecase.go:Get")
+	}
+
+	return &domain.PostWithUserSpace{
+		Post:  post,
+		Space: space,
+		User:  user,
+	}, nil
+}

--- a/internal/infrastructure/adapters/repositories/postgres/entity/post_entity.go
+++ b/internal/infrastructure/adapters/repositories/postgres/entity/post_entity.go
@@ -1,0 +1,14 @@
+package entity
+
+import "time"
+
+type PostEntity struct {
+	ID        int       `db:"id"`
+	Title     string    `db:"title"`
+	Content   string    `db:"content"`
+	CreatedBy int       `db:"created_by"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+	UpdatedBy int       `db:"updated_by"`
+	SpaceID   int       `db:"space_id"`
+}

--- a/internal/infrastructure/adapters/repositories/postgres/mapper/post_mapper.go
+++ b/internal/infrastructure/adapters/repositories/postgres/mapper/post_mapper.go
@@ -1,0 +1,32 @@
+package mapper
+
+import (
+	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/entity"
+)
+
+func ToPostgresPost(post *domain.Post) *entity.PostEntity {
+	return &entity.PostEntity{
+		ID:        post.ID,
+		Title:     post.Title,
+		Content:   post.Content,
+		CreatedBy: post.CreatedBy,
+		CreatedAt: post.CreatedAt,
+		UpdatedAt: post.UpdatedAt,
+		UpdatedBy: post.UpdatedBy,
+		SpaceID:   post.SpaceID,
+	}
+}
+
+func ToDomainPost(postEntity *entity.PostEntity) *domain.Post {
+	return &domain.Post{
+		ID:        postEntity.ID,
+		Title:     postEntity.Title,
+		Content:   postEntity.Content,
+		CreatedBy: postEntity.CreatedBy,
+		CreatedAt: postEntity.CreatedAt,
+		UpdatedAt: postEntity.UpdatedAt,
+		UpdatedBy: postEntity.UpdatedBy,
+		SpaceID:   postEntity.SpaceID,
+	}
+}

--- a/internal/infrastructure/adapters/repositories/postgres/post/post_repository.go
+++ b/internal/infrastructure/adapters/repositories/postgres/post/post_repository.go
@@ -1,0 +1,67 @@
+package post
+
+import (
+	"context"
+	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/core/domain/criteria"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/entity"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/mapper"
+	"database/sql"
+)
+
+type PostRepository struct {
+	db *sql.DB
+}
+
+func NewPostRepository(db *sql.DB) *PostRepository {
+	return &PostRepository{
+		db: db,
+	}
+}
+
+func (p *PostRepository) Create(ctx context.Context, post *domain.Post) error {
+	var postEntity = *mapper.ToPostgresPost(post)
+
+	if err := p.db.QueryRowContext(ctx,
+		"INSERT INTO posts (title, content, created_at, updated_at, created_by, updated_by, space_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id",
+		postEntity.Title, postEntity.Content, postEntity.CreatedAt, postEntity.UpdatedAt, postEntity.CreatedBy, postEntity.UpdatedBy, postEntity.SpaceID).Scan(&postEntity.ID); err != nil {
+		return err
+	}
+
+	post.ID = postEntity.ID
+	return nil
+}
+
+func (p *PostRepository) Find(ctx context.Context, criteria *criteria.Criteria) (*domain.Post, error) {
+	query, params := mapper.ToPostgreSQLQuery(criteria)
+
+	return p.findPostByField(ctx, query, params)
+}
+
+func (p *PostRepository) findPostByField(ctx context.Context, whereClause string, params []interface{}) (*domain.Post, error) {
+	var postEntity entity.PostEntity
+
+	query := `
+        SELECT id, title, content, created_by, created_at, updated_by, updated_at, space_id
+        FROM posts
+    ` + " " + whereClause + " LIMIT 1"
+
+	err := p.db.QueryRowContext(ctx, query, params...).Scan(
+		&postEntity.ID,
+		&postEntity.Title,
+		&postEntity.Content,
+		&postEntity.CreatedBy,
+		&postEntity.CreatedAt,
+		&postEntity.UpdatedBy,
+		&postEntity.UpdatedAt,
+		&postEntity.SpaceID,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return mapper.ToDomainPost(&postEntity), nil
+}

--- a/internal/infrastructure/entrypoint/handlers/post/post.go
+++ b/internal/infrastructure/entrypoint/handlers/post/post.go
@@ -1,1 +1,44 @@
 package post
+
+import (
+	"cpi-hub-api/internal/core/dto"
+	"cpi-hub-api/internal/core/usecase/post"
+	"cpi-hub-api/pkg/apperror"
+	response "cpi-hub-api/pkg/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PostHandler struct {
+	PostUseCase post.PostUseCase
+}
+
+func (h *PostHandler) Create(c *gin.Context) {
+	var postDTO dto.CreatePost
+
+	if err := c.ShouldBindJSON(&postDTO); err != nil {
+		appErr := apperror.NewInvalidData("Invalid post data", err, "post_handler.go:Create")
+		response.NewError(c.Writer, appErr)
+		return
+	}
+
+	createdPost, err := h.PostUseCase.Create(c.Request.Context(), postDTO.ToDomain())
+	if err != nil {
+		response.NewError(c.Writer, err)
+		return
+	}
+
+	response.CreatedResponse(c.Writer, "Post created successfully", dto.ToPostWithUserSpaceDTO(createdPost))
+}
+
+func (h *PostHandler) Get(c *gin.Context) {
+	postID := c.Param("post_id")
+
+	post, err := h.PostUseCase.Get(c.Request.Context(), postID)
+	if err != nil {
+		response.NewError(c.Writer, err)
+		return
+	}
+
+	response.SuccessResponse(c.Writer, "Post retrieved successfully", dto.ToPostWithUserSpaceDTO(post))
+}

--- a/internal/infrastructure/entrypoint/router/routes.go
+++ b/internal/infrastructure/entrypoint/router/routes.go
@@ -18,4 +18,9 @@ func LoadRoutes(app *gin.Engine, handlers *dependencies.Handlers) {
 	// spaces
 	v1.POST("/spaces", handlers.SpaceHandler.Create)
 	v1.GET("/spaces/:space_id", handlers.SpaceHandler.Get)
+
+	// posts
+	v1.POST("/posts", handlers.PostHandler.Create)
+	v1.GET("/posts/:post_id", handlers.PostHandler.Get)
+
 }


### PR DESCRIPTION
This pull request introduces a significant refactor and extension to the data model and business logic for spaces and posts, moving from a MongoDB-based approach to a PostgreSQL-backed implementation. It adds support for posts, updates existing space and user logic to use integer IDs, and provides new DTOs and use cases for posts. The most important changes are grouped below.

**Database and Domain Model Refactor:**

* Changed all primary and foreign key IDs for `Space`, `Post`, and related entities from `string` to `int` for PostgreSQL compatibility, and updated all references accordingly in domain models, DTOs, and repository interfaces. [[1]](diffhunk://#diff-b52c478e439761856d17c7988a2dc351a363a948740be5721207107fe9fd19c5L6-R29) [[2]](diffhunk://#diff-87255a442bd0cea5f343a8bbc2c1eaf8ee898727df344110db2190ca59cb14d2L6-R6) [[3]](diffhunk://#diff-62689c21145316e8b89c42bc9ccd298cda21d16932cb6274cb2889d7da07c4fcL15-R15) [[4]](diffhunk://#diff-62689c21145316e8b89c42bc9ccd298cda21d16932cb6274cb2889d7da07c4fcR24-R30) [[5]](diffhunk://#diff-920302405f3bcf657b0d67a90e4403d07fe872a1cd85f112ed3397e051ad7e5eL16-R27) [[6]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L14-R14) [[7]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L97-R97) [[8]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L119-R119)
* Added new PostgreSQL tables for `spaces` and `posts`, and updated the `user_spaces` table to reference integer IDs.

**Post Feature Implementation:**

* Introduced domain, DTO, and use case logic for posts, including creation and retrieval of posts with associated user and space information. [[1]](diffhunk://#diff-b52c478e439761856d17c7988a2dc351a363a948740be5721207107fe9fd19c5L6-R29) [[2]](diffhunk://#diff-2b84cc244eadac28cc4cf217cae22e45e9be010efe448fbec8e56dbcabe3f436R1-R73) [[3]](diffhunk://#diff-440971cbed9abb7d4179593f0bfcef1db3c48bcd9f0cf1c4073c6ded7446f418R1-R142)
* Added dependency injection and handler setup for posts in the application layer, wiring up repositories and use cases for the new feature. [[1]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR4-R11) [[2]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR20-R37) [[3]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR46-R48)

**Repository Layer Migration:**

* Switched repository implementations for spaces and users from MongoDB to PostgreSQL, and added a new PostgreSQL-backed post repository. [[1]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR4-R11) [[2]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR20-R37)
* Deprecated old MongoDB post and space repository code by commenting out related files and mappers. [[1]](diffhunk://#diff-c9c969e6d384976dc1d1a04f4f98b9407adde0c07664fd76fce9f02195ae57b1R1-R16) [[2]](diffhunk://#diff-cb7f114153d1aacf207997f5b2c5487690e55fa23fed75e6ff79a401ea1f4f47R1-R27) [[3]](diffhunk://#diff-88d0bfda253a8bdf10bb7185903bbc1e5580f67d5850da9aa070ccbd5584cb78L3-R25) [[4]](diffhunk://#diff-c55a2739e377f075af723ef3ea357ca9d2a84434a9d6dd41e3d21cdf1eeb7349R1-R24)

**DTO and Interface Enhancements:**

* Added new DTOs for posts, including `CreatePost`, `PostDTO`, and `PostWithUserSpaceDTO`, and updated space DTOs to use integer IDs. [[1]](diffhunk://#diff-2b84cc244eadac28cc4cf217cae22e45e9be010efe448fbec8e56dbcabe3f436R1-R73) [[2]](diffhunk://#diff-62689c21145316e8b89c42bc9ccd298cda21d16932cb6274cb2889d7da07c4fcL15-R15) [[3]](diffhunk://#diff-62689c21145316e8b89c42bc9ccd298cda21d16932cb6274cb2889d7da07c4fcR24-R30)
* Updated repository interfaces to support new integer ID types and added a `PostRepository` interface for post operations.

**Business Logic Updates:**

* Updated space and user use cases to work with integer IDs, and removed legacy ULID generation and MongoDB-specific logic. [[1]](diffhunk://#diff-45cf22445acb03c02d696f588f0ffcdf90886122bcddfd21a391757f1c3483b4L8) [[2]](diffhunk://#diff-45cf22445acb03c02d696f588f0ffcdf90886122bcddfd21a391757f1c3483b4L68) [[3]](diffhunk://#diff-45cf22445acb03c02d696f588f0ffcdf90886122bcddfd21a391757f1c3483b4L92-R90) [[4]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L14-R14) [[5]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L97-R97) [[6]](diffhunk://#diff-f3a7861194f7b1a998f854ebfe0e5fbc18915d82f62c21ca59461ccae1afc840L119-R119)

These changes collectively migrate the backend from MongoDB to PostgreSQL, introduce post management, and standardize ID types for consistency and relational integrity.