### PR TITLE
feat: add search functionality for posts by title or content

### DIFF
--- a/internal/core/domain/repositories.go
+++ b/internal/core/domain/repositories.go
@@ -25,6 +25,8 @@ type UserSpaceRepository interface {
 type PostRepository interface {
 	Create(ctx context.Context, post *Post) error
 	Find(ctx context.Context, criteria *criteria.Criteria) (*Post, error)
+	FindAll(ctx context.Context, criteria *criteria.Criteria) ([]*Post, error)
+	SearchByTitleOrContent(ctx context.Context, query string) ([]*Post, error)
 }
 
 type CommentRepository interface {

--- a/internal/core/dto/post.go
+++ b/internal/core/dto/post.go
@@ -54,6 +54,15 @@ func ToPostDTO(post *domain.Post) PostDTO {
 	}
 }
 
+func ToPostDTOs(posts []*domain.Post) []PostDTO {
+	var postDTOs []PostDTO
+	for _, post := range posts {
+		postDTOs = append(postDTOs, ToPostDTO(post))
+	}
+
+	return postDTOs
+}
+
 func ToPostExtendedDTO(post *domain.ExtendedPost) PostExtendedDTO {
 	commentsDTO := make([]CommentWithUserDTO, 0, len(post.Comments))
 

--- a/internal/core/dto/post.go
+++ b/internal/core/dto/post.go
@@ -55,7 +55,7 @@ func ToPostDTO(post *domain.Post) PostDTO {
 }
 
 func ToPostDTOs(posts []*domain.Post) []PostDTO {
-	var postDTOs []PostDTO
+	postDTOs := make([]PostDTO, 0, len(posts))
 	for _, post := range posts {
 		postDTOs = append(postDTOs, ToPostDTO(post))
 	}

--- a/internal/core/usecase/post/post_usecase.go
+++ b/internal/core/usecase/post/post_usecase.go
@@ -12,6 +12,7 @@ type PostUseCase interface {
 	Create(ctx context.Context, post *domain.Post) (*domain.ExtendedPost, error)
 	Get(ctx context.Context, id int) (*domain.ExtendedPost, error)
 	AddComment(ctx context.Context, comment *domain.Comment) (*domain.CommentWithUser, error)
+	SearchPosts(ctx context.Context, query string) ([]*domain.Post, error)
 }
 
 type postUseCase struct {
@@ -125,4 +126,13 @@ func (c postUseCase) AddComment(ctx context.Context, comment *domain.Comment) (*
 		Comment: comment,
 		User:    user,
 	}, nil
+}
+
+func (p *postUseCase) SearchPosts(ctx context.Context, query string) ([]*domain.Post, error) {
+	posts, err := p.postRepository.SearchByTitleOrContent(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return posts, nil
 }

--- a/internal/infrastructure/adapters/repositories/postgres/post/post_repository.go
+++ b/internal/infrastructure/adapters/repositories/postgres/post/post_repository.go
@@ -91,11 +91,10 @@ func (p *PostRepository) SearchByTitleOrContent(ctx context.Context, query strin
 	sqlQuery := `
         SELECT id, title, content, created_by, created_at, updated_by, updated_at, space_id
         FROM posts
-        WHERE title ILIKE $1 OR content ILIKE $1
+        WHERE title ILIKE '%' || $1 || '%' OR content ILIKE '%' || $1 || '%'
     `
 
-	searchPattern := "%" + query + "%"
-	rows, err := p.db.QueryContext(ctx, sqlQuery, searchPattern)
+	rows, err := p.db.QueryContext(ctx, sqlQuery, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/entrypoint/handlers/post/post.go
+++ b/internal/infrastructure/entrypoint/handlers/post/post.go
@@ -76,3 +76,19 @@ func (h *PostHandler) AddComment(c *gin.Context) {
 
 	response.CreatedResponse(c.Writer, "Comment created successfully", dto.ToCommentWithUserAndPostDTO(createdComment))
 }
+
+func (h *PostHandler) SearchPosts(context *gin.Context) {
+	searchQuery := context.Query("q")
+	if searchQuery == "" {
+		appErr := apperror.NewInvalidData("Query parameter 'q' is required", nil, "post_handler.go:SearchPosts")
+		response.NewError(context.Writer, appErr)
+		return
+	}
+	posts, err := h.PostUseCase.SearchPosts(context.Request.Context(), searchQuery)
+	if err != nil {
+		response.NewError(context.Writer, err)
+		return
+	}
+
+	response.SuccessResponse(context.Writer, "Posts retrieved successfully", dto.ToPostDTOs(posts))
+}

--- a/internal/infrastructure/entrypoint/router/routes.go
+++ b/internal/infrastructure/entrypoint/router/routes.go
@@ -22,6 +22,7 @@ func LoadRoutes(app *gin.Engine, handlers *dependencies.Handlers) {
 	// posts
 	v1.POST("/posts", handlers.PostHandler.Create)
 	v1.GET("/posts/:post_id", handlers.PostHandler.Get)
+	v1.GET("/posts/search", handlers.PostHandler.SearchPosts)
 	//comments
 	v1.POST("/posts/:post_id/comments", handlers.PostHandler.AddComment)
 


### PR DESCRIPTION
This pull request introduces a new search feature for posts, allowing users to search for posts by their title or content. The implementation includes updates across the domain, use case, repository, DTO, handler, and router layers to support searching and returning multiple posts.

**Search functionality for posts:**

* Added `SearchPosts` method to the `PostUseCase` interface and implemented it to query posts by title or content using the repository layer. [[1]](diffhunk://#diff-440971cbed9abb7d4179593f0bfcef1db3c48bcd9f0cf1c4073c6ded7446f418R15) [[2]](diffhunk://#diff-440971cbed9abb7d4179593f0bfcef1db3c48bcd9f0cf1c4073c6ded7446f418R130-R138)
* Extended the `PostRepository` interface and its Postgres implementation to support finding all posts by criteria and searching posts by title or content. Refactored the query logic for efficiency and reusability. [[1]](diffhunk://#diff-920302405f3bcf657b0d67a90e4403d07fe872a1cd85f112ed3397e051ad7e5eR28-R29) [[2]](diffhunk://#diff-a71b5af6237bbeda83bc1332c912437691d3ce8943907abbd1b58522265a9d23R37-R78) [[3]](diffhunk://#diff-a71b5af6237bbeda83bc1332c912437691d3ce8943907abbd1b58522265a9d23R88-R113)

**DTO and handler updates:**

* Added `ToPostDTOs` function to convert a list of domain posts to DTOs for API responses.
* Implemented `SearchPosts` handler to process search requests, validate input, and return results in the expected format.

**Routing changes:**

* Registered a new route `GET /posts/search` to expose the search functionality via the API.