### PR TITLE
feat: add name filter to space search criteria and handler

### DIFF
--- a/internal/core/domain/space.go
+++ b/internal/core/domain/space.go
@@ -24,6 +24,7 @@ type SpaceCounts struct {
 }
 
 type SpaceSearchCriteria struct {
+	Name          *string
 	CreatedBy     *int
 	OrderBy       string
 	Page          int

--- a/internal/core/dto/space.go
+++ b/internal/core/dto/space.go
@@ -27,11 +27,12 @@ type SimpleSpaceDto struct {
 }
 
 type SearchSpacesDTO struct {
-	CreatedBy     *int   `form:"created_by" json:"created_by"`
-	OrderBy       string `form:"order_by" json:"order_by"`
-	Page          int    `form:"page" json:"page"`
-	PageSize      int    `form:"page_size" json:"page_size"`
-	SortDirection string `form:"sort_direction" json:"sort_direction"`
+	Name          *string `form:"name" json:"name"`
+	CreatedBy     *int    `form:"created_by" json:"created_by"`
+	OrderBy       string  `form:"order_by" json:"order_by"`
+	Page          int     `form:"page" json:"page"`
+	PageSize      int     `form:"page_size" json:"page_size"`
+	SortDirection string  `form:"sort_direction" json:"sort_direction"`
 }
 
 type SearchSpacesResponseDTO struct {

--- a/internal/core/usecase/space/space_usecase.go
+++ b/internal/core/usecase/space/space_usecase.go
@@ -186,6 +186,10 @@ func (s *spaceUseCase) Search(ctx context.Context, searchCriteria *domain.SpaceS
 		WithSort(searchCriteria.OrderBy, direction).
 		WithPagination(searchCriteria.Page, searchCriteria.PageSize)
 
+	if searchCriteria.Name != nil {
+		criteriaBuilder.WithFilter("name", "%"+*searchCriteria.Name+"%", criteria.OperatorILike)
+	}
+
 	if searchCriteria.CreatedBy != nil {
 		criteriaBuilder.WithFilter("created_by", *searchCriteria.CreatedBy, criteria.OperatorEqual)
 	}

--- a/internal/infrastructure/entrypoint/handlers/space/space.go
+++ b/internal/infrastructure/entrypoint/handlers/space/space.go
@@ -58,6 +58,7 @@ func (h *SpaceHandler) Search(context *gin.Context) {
 	orderBy, sortDirection := helpers.GetSortValues(context)
 
 	searchCriteria := &domain.SpaceSearchCriteria{
+		Name:          searchDTO.Name,
 		CreatedBy:     searchDTO.CreatedBy,
 		OrderBy:       orderBy,
 		Page:          page,


### PR DESCRIPTION
This pull request adds support for searching spaces by their name. The main changes involve updating the search criteria and DTOs to include a `Name` field, and modifying the search logic to filter results by name when provided.

**Search functionality enhancements:**

* Added a `Name` field to the `SpaceSearchCriteria` struct in `internal/core/domain/space.go` to allow searching by space name.
* Added a `Name` field to the `SearchSpacesDTO` struct in `internal/core/dto/space.go` so the API can accept a name parameter for searches.
* Updated the `Search` method in `internal/core/usecase/space/space_usecase.go` to filter spaces by name using a case-insensitive like (`ILIKE`) operator if the name is provided.
* Modified the handler in `internal/infrastructure/entrypoint/handlers/space/space.go` to pass the name from the DTO to the search criteria.