### PR TITLE
feat: add search query parameter to SpaceSearchCriteria and update Se…

### DIFF
--- a/internal/core/domain/space.go
+++ b/internal/core/domain/space.go
@@ -30,6 +30,7 @@ type SpaceSearchCriteria struct {
 	Page          int
 	PageSize      int
 	SortDirection string
+	Query         string
 }
 
 type SearchResult struct {

--- a/internal/infrastructure/entrypoint/handlers/space/space.go
+++ b/internal/infrastructure/entrypoint/handlers/space/space.go
@@ -64,6 +64,7 @@ func (h *SpaceHandler) Search(context *gin.Context) {
 		Page:          page,
 		PageSize:      pageSize,
 		SortDirection: sortDirection,
+		Query:         context.Query("q"),
 	}
 
 	searchResult, err := h.SpaceUseCase.Search(context.Request.Context(), searchCriteria)


### PR DESCRIPTION
This pull request enhances the space search functionality by introducing a general search query parameter that allows users to search across both the `name` and `description` fields of spaces. The implementation adds a new `Query` field to the search criteria and updates the search logic to support partial matches using case-insensitive queries.

**Search improvements:**

* Added a `Query` field to the `SpaceSearchCriteria` struct to support general search input.
* Updated the `SpaceHandler` to extract the `q` query parameter from requests and pass it into the search criteria.
* Enhanced the `Search` method in `spaceUseCase` to process the `Query` parameter, building a wildcard search string if the query is longer than two characters.
* Modified the search criteria builder to apply case-insensitive partial matching (`ILIKE`) filters on both the `name` and `description` fields when a query is provided.

**Code maintenance:**

* Imported the `strings` package to support trimming and formatting of the search query.