### PR TITLE
feat: set default user image if none is provided during user creation

### DIFF
--- a/internal/core/usecase/user/user_usecase.go
+++ b/internal/core/usecase/user/user_usecase.go
@@ -56,6 +56,10 @@ func (u *useCase) Create(ctx context.Context, user *domain.User) (*domain.User, 
 	user.CreatedAt = time.Now()
 	user.UpdatedAt = time.Now()
 
+	if user.Image == "" {
+		user.Image = "https://i.pinimg.com/736x/fb/6c/1f/fb6c1f3561169051c01cfb74d73d93b7.jpg"
+	}
+
 	cryptedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, apperror.NewInvalidData("Failed to hash password", err, "user_usecase.go:Create")


### PR DESCRIPTION
This pull request introduces a small but important improvement to user creation logic by ensuring that every new user has a default profile image if none is provided.

- User creation enhancement:
  * In the `Create` method of `user_usecase.go`, a default image URL is assigned to `user.Image` if it is empty, ensuring all users have a profile image.