### PR TITLE
Feature/news

### DIFF
--- a/database/schema/init.go
+++ b/database/schema/init.go
@@ -60,7 +60,7 @@ func EnsureSchema(db *sql.DB) error {
             username TEXT NOT NULL,
             space_id INT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
             timestamp TIMESTAMP NOT NULL DEFAULT now()
-)`,
+        )`,
 	}
 
 	for _, stmt := range stmts {

--- a/internal/app/dependencies/dependencies.go
+++ b/internal/app/dependencies/dependencies.go
@@ -4,11 +4,13 @@ import (
 	commentUsecase "cpi-hub-api/internal/core/usecase/comment"
 	eventsUsecase "cpi-hub-api/internal/core/usecase/events"
 	messageUsecase "cpi-hub-api/internal/core/usecase/message"
+	newsUsecase "cpi-hub-api/internal/core/usecase/news"
 	notificationUsecase "cpi-hub-api/internal/core/usecase/notification"
 	postUsecase "cpi-hub-api/internal/core/usecase/post"
 	reactionUsecase "cpi-hub-api/internal/core/usecase/reaction"
 	spaceUsecase "cpi-hub-api/internal/core/usecase/space"
 	userUsecase "cpi-hub-api/internal/core/usecase/user"
+	newsRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/news"
 	notificationRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/notification"
 	reactionRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/reaction"
 	commentRepository "cpi-hub-api/internal/infrastructure/adapters/repositories/postgres/comment"
@@ -21,6 +23,7 @@ import (
 	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/comment"
 	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/events"
 	messageHandler "cpi-hub-api/internal/infrastructure/entrypoint/handlers/message"
+	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/news"
 	notificationHandler "cpi-hub-api/internal/infrastructure/entrypoint/handlers/notification"
 	"cpi-hub-api/internal/infrastructure/entrypoint/handlers/post"
 	reactionHandler "cpi-hub-api/internal/infrastructure/entrypoint/handlers/reaction"
@@ -38,6 +41,7 @@ type Handlers struct {
 	MessageHandler      *messageHandler.MessageHandler
 	ReactionHandler     *reactionHandler.ReactionHandler
 	NotificationHandler *notificationHandler.NotificationHandler
+	NewsHandler         *news.NewsHandler
 }
 
 func Build() *Handlers {
@@ -61,12 +65,14 @@ func Build() *Handlers {
 	messageRepo := messageRepository.NewMessageRepository(sqldb)
 	reactionRepo := reactionRepository.NewReactionRepository(mongodb)
 	notificationRepo := notificationRepository.NewNotificationRepository(mongodb)
+	newsRepo := newsRepository.NewNewsRepository(mongodb)
 
 	userUsecase := userUsecase.NewUserUsecase(userRepository, spaceRepository, userSpaceRepository)
 	spaceUsecase := spaceUsecase.NewSpaceUsecase(spaceRepository, userRepository, userSpaceRepository, postRepository)
 	postUsecase := postUsecase.NewPostUsecase(postRepository, spaceRepository, userRepository, commentRepository, userSpaceRepository)
 	commentUsecase := commentUsecase.NewCommentUsecase(commentRepository)
 	messageUsecase := messageUsecase.NewMessageUsecase(messageRepo)
+	newsUsecase := newsUsecase.NewNewsUsecase(newsRepo)
 
 	hubManager := eventsUsecase.NewHubManager()
 	go hubManager.Run()
@@ -101,5 +107,8 @@ func Build() *Handlers {
 			ReactionUseCase: reactionUsecase,
 		},
 		NotificationHandler: notificationHandler.NewNotificationHandler(notificationUsecase),
+		NewsHandler: &news.NewsHandler{
+			NewsUseCase: newsUsecase,
+		},
 	}
 }

--- a/internal/core/domain/news.go
+++ b/internal/core/domain/news.go
@@ -3,9 +3,10 @@ package domain
 import "time"
 
 type News struct {
-	ID        int
-	Content   string
-	Image     string
-	CreatedAt time.Time
-	ExpiresAt *time.Time
+	ID          string
+	Content     string
+	Image       string
+	RedirectURL string
+	CreatedAt   time.Time
+	ExpiresAt   *time.Time
 }

--- a/internal/core/domain/news.go
+++ b/internal/core/domain/news.go
@@ -1,0 +1,11 @@
+package domain
+
+import "time"
+
+type News struct {
+	ID        int
+	Content   string
+	Image     string
+	CreatedAt time.Time
+	ExpiresAt *time.Time
+}

--- a/internal/core/domain/repositories.go
+++ b/internal/core/domain/repositories.go
@@ -81,3 +81,8 @@ type NotificationRepository interface {
 	MarkAllAsRead(ctx context.Context, userID int) error
 	GetUnreadCount(ctx context.Context, userID int) (int, error)
 }
+
+type NewsRepository interface {
+	GetAll(ctx context.Context) ([]*News, error)
+	Create(ctx context.Context, news *News) (*News, error)
+}

--- a/internal/core/domain/repositories.go
+++ b/internal/core/domain/repositories.go
@@ -83,6 +83,6 @@ type NotificationRepository interface {
 }
 
 type NewsRepository interface {
-	GetAll(ctx context.Context) ([]*News, error)
+	GetAll(ctx context.Context, criteria *criteria.Criteria) ([]*News, error)
 	Create(ctx context.Context, news *News) (*News, error)
 }

--- a/internal/core/dto/new.go
+++ b/internal/core/dto/new.go
@@ -1,0 +1,21 @@
+package dto
+
+import (
+	"cpi-hub-api/internal/core/domain"
+	"time"
+)
+
+type CreateNewsDTO struct {
+	Content   string     `json:"content" binding:"required"`
+	Image     string     `json:"image,omitempty"`
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+}
+
+func (dto *CreateNewsDTO) ToDomain() domain.News {
+	news := domain.News{
+		Content:   dto.Content,
+		Image:     dto.Image,
+		ExpiresAt: dto.ExpiresAt,
+	}
+	return news
+}

--- a/internal/core/dto/new.go
+++ b/internal/core/dto/new.go
@@ -6,16 +6,18 @@ import (
 )
 
 type CreateNewsDTO struct {
-	Content   string     `json:"content" binding:"required"`
-	Image     string     `json:"image,omitempty"`
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Content     string     `json:"content" binding:"required"`
+	Image       string     `json:"image,omitempty"`
+	RedirectURL string     `json:"redirect_url,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 }
 
 func (dto *CreateNewsDTO) ToDomain() domain.News {
 	news := domain.News{
-		Content:   dto.Content,
-		Image:     dto.Image,
-		ExpiresAt: dto.ExpiresAt,
+		Content:     dto.Content,
+		Image:       dto.Image,
+		ExpiresAt:   dto.ExpiresAt,
+		RedirectURL: dto.RedirectURL,
 	}
 	return news
 }

--- a/internal/core/usecase/news/new_usecase.go
+++ b/internal/core/usecase/news/new_usecase.go
@@ -1,0 +1,39 @@
+package news
+
+import (
+	"context"
+	"cpi-hub-api/internal/core/domain"
+)
+
+type NewsUseCase interface {
+	GetAllNews(ctx context.Context) ([]*domain.News, error)
+	CreateNews(ctx context.Context, new domain.News) (*domain.News, error)
+}
+
+type newsUsecase struct {
+	newsRepository domain.NewsRepository
+}
+
+func NewNewsUsecase(newsRepo domain.NewsRepository) NewsUseCase {
+	return &newsUsecase{
+		newsRepository: newsRepo,
+	}
+}
+
+func (u *newsUsecase) GetAllNews(ctx context.Context) ([]*domain.News, error) {
+	newsItems, err := u.newsRepository.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return newsItems, nil
+}
+
+func (u *newsUsecase) CreateNews(ctx context.Context, new domain.News) (*domain.News, error) {
+	createdNews, err := u.newsRepository.Create(ctx, &new)
+	if err != nil {
+		return nil, err
+	}
+
+	return createdNews, nil
+}

--- a/internal/core/usecase/news/new_usecase.go
+++ b/internal/core/usecase/news/new_usecase.go
@@ -3,6 +3,7 @@ package news
 import (
 	"context"
 	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/core/domain/criteria"
 	"cpi-hub-api/pkg/helpers"
 )
 
@@ -22,7 +23,13 @@ func NewNewsUsecase(newsRepo domain.NewsRepository) NewsUseCase {
 }
 
 func (u *newsUsecase) GetAllNews(ctx context.Context) ([]*domain.News, error) {
-	newsItems, err := u.newsRepository.GetAll(ctx)
+
+	now := helpers.GetTime()
+	searchCriteria := criteria.NewCriteriaBuilder().
+		WithFilter("expires_at", now, criteria.OperatorGte).
+		Build()
+
+	newsItems, err := u.newsRepository.GetAll(ctx, searchCriteria)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/usecase/news/new_usecase.go
+++ b/internal/core/usecase/news/new_usecase.go
@@ -3,6 +3,7 @@ package news
 import (
 	"context"
 	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/pkg/helpers"
 )
 
 type NewsUseCase interface {
@@ -30,6 +31,15 @@ func (u *newsUsecase) GetAllNews(ctx context.Context) ([]*domain.News, error) {
 }
 
 func (u *newsUsecase) CreateNews(ctx context.Context, new domain.News) (*domain.News, error) {
+
+	new.CreatedAt = helpers.GetTime()
+
+	//si no se indicó fecha de expiración, se asigna 1 mes desde la creación
+	if new.ExpiresAt == nil {
+		t := new.CreatedAt.AddDate(0, 1, 0)
+		new.ExpiresAt = &t
+	}
+
 	createdNews, err := u.newsRepository.Create(ctx, &new)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/adapters/repositories/mongo/entity/news_entity.go
+++ b/internal/infrastructure/adapters/repositories/mongo/entity/news_entity.go
@@ -1,0 +1,12 @@
+package entity
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type News struct {
+	ID          primitive.ObjectID  `bson:"_id,omitempty"`
+	Content     string              `bson:"content"`
+	Image       string              `bson:"image,omitempty"`
+	RedirectURL string              `bson:"redirect_url,omitempty"`
+	ExpiresAt   *primitive.DateTime `bson:"expires_at,omitempty"`
+	CreatedAt   primitive.DateTime  `bson:"created_at"`
+}

--- a/internal/infrastructure/adapters/repositories/mongo/mapper/news_mapper.go
+++ b/internal/infrastructure/adapters/repositories/mongo/mapper/news_mapper.go
@@ -1,0 +1,54 @@
+package mapper
+
+import (
+	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/entity"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func ToMongoNews(news *domain.News) *entity.News {
+	var oid primitive.ObjectID
+	if news.ID != "" {
+		if parsed, err := primitive.ObjectIDFromHex(news.ID); err == nil {
+			oid = parsed
+		}
+	}
+
+	var expiresAt *primitive.DateTime
+	if news.ExpiresAt != nil {
+		dt := primitive.NewDateTimeFromTime(*news.ExpiresAt)
+		expiresAt = &dt
+	}
+
+	return &entity.News{
+		ID:          oid,
+		Content:     news.Content,
+		Image:       news.Image,
+		RedirectURL: news.RedirectURL,
+		ExpiresAt:   expiresAt,
+		CreatedAt:   primitive.NewDateTimeFromTime(news.CreatedAt),
+	}
+}
+
+func ToDomainNews(newsEntity *entity.News) *domain.News {
+	var idStr string
+	if newsEntity.ID != primitive.NilObjectID {
+		idStr = newsEntity.ID.Hex()
+	}
+	var expiresAt *time.Time
+	if newsEntity.ExpiresAt != nil {
+		t := newsEntity.ExpiresAt.Time()
+		expiresAt = &t
+	}
+
+	return &domain.News{
+		ID:          idStr,
+		Content:     newsEntity.Content,
+		Image:       newsEntity.Image,
+		RedirectURL: newsEntity.RedirectURL,
+		ExpiresAt:   expiresAt,
+		CreatedAt:   newsEntity.CreatedAt.Time(),
+	}
+}

--- a/internal/infrastructure/adapters/repositories/mongo/news/news_repository.go
+++ b/internal/infrastructure/adapters/repositories/mongo/news/news_repository.go
@@ -1,0 +1,59 @@
+package news
+
+import (
+	"context"
+	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/entity"
+	"cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/mapper"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type NewsRepository struct {
+	db *mongo.Database
+}
+
+func NewNewsRepository(db *mongo.Database) *NewsRepository {
+	return &NewsRepository{db: db}
+}
+
+func (r *NewsRepository) GetAll(ctx context.Context) ([]*domain.News, error) {
+
+	collection := r.db.Collection("news")
+
+	cursor, err := collection.Find(ctx, bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var newsItems []*domain.News
+	for cursor.Next(ctx) {
+		var newsEntity entity.News
+		if err := cursor.Decode(&newsEntity); err != nil {
+			return nil, err
+		}
+		news := mapper.ToDomainNews(&newsEntity)
+		newsItems = append(newsItems, news)
+	}
+	return newsItems, nil
+}
+
+func (r *NewsRepository) Create(ctx context.Context, news *domain.News) (*domain.News, error) {
+	newsEntity := mapper.ToMongoNews(news)
+
+	collection := r.db.Collection("news")
+
+	res, err := collection.InsertOne(ctx, newsEntity)
+	if err != nil {
+		return nil, err
+	}
+
+	if oid, ok := res.InsertedID.(primitive.ObjectID); ok {
+		news.ID = oid.Hex()
+	}
+
+	return news, nil
+}

--- a/internal/infrastructure/adapters/repositories/mongo/news/news_repository.go
+++ b/internal/infrastructure/adapters/repositories/mongo/news/news_repository.go
@@ -3,6 +3,7 @@ package news
 import (
 	"context"
 	"cpi-hub-api/internal/core/domain"
+	"cpi-hub-api/internal/core/domain/criteria"
 	"cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/entity"
 	"cpi-hub-api/internal/infrastructure/adapters/repositories/mongo/mapper"
 
@@ -19,11 +20,19 @@ func NewNewsRepository(db *mongo.Database) *NewsRepository {
 	return &NewsRepository{db: db}
 }
 
-func (r *NewsRepository) GetAll(ctx context.Context) ([]*domain.News, error) {
+func (r *NewsRepository) GetAll(ctx context.Context, crit *criteria.Criteria) ([]*domain.News, error) {
 
 	collection := r.db.Collection("news")
 
-	cursor, err := collection.Find(ctx, bson.M{})
+	filter := bson.M{}
+	if crit != nil && len(crit.Filters) > 0 {
+		criteriaFilter := mapper.ToMongoDBQuery(crit)
+		for _, elem := range criteriaFilter {
+			filter[elem.Key] = elem.Value
+		}
+	}
+
+	cursor, err := collection.Find(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/entrypoint/handlers/news/news.go
+++ b/internal/infrastructure/entrypoint/handlers/news/news.go
@@ -1,0 +1,48 @@
+package news
+
+import (
+	"cpi-hub-api/internal/core/dto"
+	newsUsecase "cpi-hub-api/internal/core/usecase/news"
+
+	response "cpi-hub-api/pkg/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type NewsHandler struct {
+	NewsUseCase newsUsecase.NewsUseCase
+}
+
+func NewNewsHandler(newsUseCase newsUsecase.NewsUseCase) *NewsHandler {
+	return &NewsHandler{
+		NewsUseCase: newsUseCase,
+	}
+}
+
+func (h *NewsHandler) GetAll(c *gin.Context) {
+
+	newsItems, err := h.NewsUseCase.GetAllNews(c.Request.Context())
+	if err != nil {
+		response.NewError(c.Writer, err)
+		return
+	}
+
+	response.SuccessResponse(c.Writer, newsItems)
+}
+
+func (h *NewsHandler) Create(c *gin.Context) {
+
+	var createNewsDTO dto.CreateNewsDTO
+	if err := c.ShouldBindJSON(&createNewsDTO); err != nil {
+		response.NewError(c.Writer, err)
+		return
+	}
+
+	newsItem, err := h.NewsUseCase.CreateNews(c.Request.Context(), createNewsDTO.ToDomain())
+	if err != nil {
+		response.NewError(c.Writer, err)
+		return
+	}
+
+	response.SuccessResponse(c.Writer, newsItem)
+}

--- a/internal/infrastructure/entrypoint/router/routes.go
+++ b/internal/infrastructure/entrypoint/router/routes.go
@@ -66,4 +66,8 @@ func LoadRoutes(app *gin.Engine, handlers *dependencies.Handlers) {
 	v1.POST("/reactions", handlers.ReactionHandler.AddReaction)
 	v1.POST("/reactions/count", handlers.ReactionHandler.GetLikesCount)
 	v1.DELETE("/reactions/:reaction_id", handlers.ReactionHandler.RemoveReaction)
+
+	// news
+	v1.GET("/news", handlers.NewsHandler.GetAll)
+	v1.POST("/news", handlers.NewsHandler.Create)
 }


### PR DESCRIPTION
This pull request introduces a new "News" feature to the application, implementing full support for creating and retrieving news items. The changes include the addition of domain models, repository and usecase layers, HTTP handlers, and new API routes. The implementation uses MongoDB as the storage backend for news items and follows the existing architectural patterns of the codebase.

**News Feature Implementation:**

*Domain and DTO Layer:*
- Added a new `News` domain model to represent news items, including fields for content, image, redirect URL, creation, and expiration dates. (`internal/core/domain/news.go`)
- Introduced a `CreateNewsDTO` for handling incoming news creation requests, along with a mapping method to convert DTOs to domain models. (`internal/core/dto/new.go`)

*Repository and Data Mapping:*
- Implemented a MongoDB-backed `NewsRepository` with methods to create and retrieve all news items, including entity and mapper logic for converting between domain and MongoDB representations. (`internal/infrastructure/adapters/repositories/mongo/news/news_repository.go`, `entity/news_entity.go`, `mapper/news_mapper.go`) [[1]](diffhunk://#diff-6b540d8d4efdabe0357495b5b11919104d8feec0b34f69e4d7db8ae1b3eaf75fR1-R59) [[2]](diffhunk://#diff-6ce5f5e93d9e664fa6bf2d8cdc0fe001936547d1600d9eb2b84ce6bd02b9427bR1-R12) [[3]](diffhunk://#diff-7f201ca4cdf1a55a3d49ce37ea836fd3ab210760c43f415fdece5624f970ade1R1-R54)
- Defined a `NewsRepository` interface in the domain layer for abstraction. (`internal/core/domain/repositories.go`)

*Usecase and Business Logic:*
- Added a `NewsUseCase` interface and implementation, providing business logic for creating news (with automatic expiration if not set) and retrieving all news. (`internal/core/usecase/news/new_usecase.go`)

*HTTP Handler and Routing:*
- Created a `NewsHandler` with endpoints for listing and creating news, following the established handler pattern. (`internal/infrastructure/entrypoint/handlers/news/news.go`)
- Registered the new news endpoints (`/news` GET and POST) in the API router. (`internal/infrastructure/entrypoint/router/routes.go`)

*Dependency Injection and Wiring:*
- Integrated the news repository, usecase, and handler into the application's dependency injection setup, ensuring all layers are properly connected. (`internal/app/dependencies/dependencies.go`) [[1]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR7-R13) [[2]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR26) [[3]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR44) [[4]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR68-R75) [[5]](diffhunk://#diff-16df7d93a40f3d09e8847f4844ed91e8bee258baad9e473e04d8809c783bfbbeR110-R112)

These changes collectively add the ability for clients to create and fetch news items via the API, with data persisted in MongoDB and expiration logic handled automatically.